### PR TITLE
add wmv extension to S3 notification

### DIFF
--- a/source/custom-resource/lib/s3/index.js
+++ b/source/custom-resource/lib/s3/index.js
@@ -86,6 +86,18 @@ const putNotification = async (bucket,lambdaArn) => {
                             Key: {
                                 FilterRules: [{
                                     Name: 'suffix',
+                                    Value: '.wmv'
+                                }]
+                            }
+                        }
+                    },
+                    {
+                        Events: ['s3:ObjectCreated:*'],
+                        LambdaFunctionArn: lambdaArn,
+                        Filter: {
+                            Key: {
+                                FilterRules: [{
+                                    Name: 'suffix',
                                     Value: '.mov'
                                 }]
                             }


### PR DESCRIPTION
*Issue #8*

*Description of changes:* Add the .wmv (Windows Media Video File) extension to S3 notification.  I want to include this video format to this workflow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
